### PR TITLE
Test changed to work on older kernels

### DIFF
--- a/test_package/test_package.c
+++ b/test_package/test_package.c
@@ -5,9 +5,11 @@
 #include <netinet/sctp.h>
 #include <string.h>
 #include <stdio.h>
+#include <linux/version.h>
 
 int main(int argc, char **argv) {
     int fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP );
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,32)
     const char* argument = {""};
     const char* with_sctp_option = "with_sctp";
     int ret = 0;
@@ -20,6 +22,7 @@ int main(int argc, char **argv) {
     ret = sctp_getaddrlen(AF_INET);
     printf("sctp_getaddrlen: %d\n", ret);
     socklen_t len = sizeof(prot);
+
     getsockopt( fd, SOL_SOCKET, SO_PROTOCOL, &prot, &len );
     printf("getsockopt: %d\n", prot);
 
@@ -28,4 +31,8 @@ int main(int argc, char **argv) {
     } else {
         return !((prot == IPPROTO_TCP) && (ret));
     }
+#else
+    return fd != -1;
+#endif
 }
+


### PR DESCRIPTION
Socket option used for test was only introduced in 2.6.32. For the few
unfortunate souls that still depend older systems and compilers like gcc
4.1 this is a no go.